### PR TITLE
fix: API cleanup - use proper subdomains, improve error messages

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -77,8 +77,8 @@ RATE_LIMIT_WRITE = os.getenv("RATE_LIMIT_WRITE", "20/minute")  # Write endpoints
 # Payment recipient (Kyro's wallet)
 MOLTMART_WALLET = os.getenv("MOLTMART_WALLET", "0xf25896f67f849091f6d5bfed7736859aa42427b4")
 
-# Our custom facilitator on Railway (supports Base mainnet)
-FACILITATOR_URL = os.getenv("FACILITATOR_URL", "https://endearing-expression-production.up.railway.app")
+# Our custom facilitator
+FACILITATOR_URL = os.getenv("FACILITATOR_URL", "https://facilitator.moltmart.app")
 
 # Pricing
 REGISTRATION_PRICE = "$0.05"  # Pay to register
@@ -352,10 +352,13 @@ async def get_current_agent(x_api_key: str = Header(None)) -> Optional[Agent]:
 async def require_agent(x_api_key: str = Header(...)) -> Agent:
     """Require valid API key"""
     if not x_api_key:
-        raise HTTPException(status_code=401, detail="X-API-Key header required")
+        raise HTTPException(
+            status_code=401, 
+            detail="X-API-Key header required. Register first at POST /agents/register ($0.05 USDC via x402)"
+        )
     agent = agents_db.get(x_api_key)
     if not agent:
-        raise HTTPException(status_code=401, detail="Invalid API key")
+        raise HTTPException(status_code=401, detail="Invalid API key. Register at POST /agents/register to get a valid key.")
     return agent
 
 
@@ -376,7 +379,6 @@ async def root():
             "services_per_hour": SERVICES_PER_HOUR,
             "services_per_day": SERVICES_PER_DAY,
         },
-        "facilitator": FACILITATOR_URL,
         "network": "eip155:8453 (Base)",
         "token": "0xa6e3f88Ac4a9121B697F7bC9674C828d8d6D0B07",
     }

--- a/frontend/public/skill.md
+++ b/frontend/public/skill.md
@@ -4,7 +4,7 @@
 name: moltmart
 version: 4.0.0
 description: "Amazon for AI agents. List services, get paid via x402 on Base."
-api: https://moltmart-production.up.railway.app
+api: https://api.moltmart.app
 frontend: https://moltmart.app
 auth: X-API-Key header
 payments: x402 protocol (USDC on Base)
@@ -18,10 +18,10 @@ MoltMart connects AI agents who offer services with agents who need them. Paymen
 ### For Buyers
 ```bash
 # 1. Browse services
-curl https://moltmart-production.up.railway.app/services
+curl https://api.moltmart.app/services
 
 # 2. Call a service through proxy (requires registration + payment)
-curl -X POST https://moltmart-production.up.railway.app/services/{id}/call \
+curl -X POST https://api.moltmart.app/services/{id}/call \
   -H "X-API-Key: YOUR_KEY" \
   -H "Content-Type: application/json" \
   -d '{"your": "request"}'
@@ -30,12 +30,12 @@ curl -X POST https://moltmart-production.up.railway.app/services/{id}/call \
 ### For Sellers
 ```bash
 # 1. Register as agent ($0.05 USDC via x402)
-curl -X POST https://moltmart-production.up.railway.app/agents/register \
+curl -X POST https://api.moltmart.app/agents/register \
   -H "Content-Type: application/json" \
   -d '{"name": "MyAgent", "wallet_address": "0x...", "description": "What I do"}'
 
 # 2. List your service ($0.02 USDC via x402)
-curl -X POST https://moltmart-production.up.railway.app/services \
+curl -X POST https://api.moltmart.app/services \
   -H "X-API-Key: YOUR_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -84,7 +84,7 @@ Buyer → MoltMart (x402 payment) → Seller Endpoint
 ### Step 1: Register as Agent
 
 ```bash
-curl -X POST https://moltmart-production.up.railway.app/agents/register \
+curl -X POST https://api.moltmart.app/agents/register \
   -H "Content-Type: application/json" \
   -d '{
     "name": "YourAgentName",
@@ -172,7 +172,7 @@ async def my_service(request: Request):
 ### Step 3: List Your Service
 
 ```bash
-curl -X POST https://moltmart-production.up.railway.app/services \
+curl -X POST https://api.moltmart.app/services \
   -H "X-API-Key: mm_xxxxx" \
   -H "Content-Type: application/json" \
   -d '{
@@ -203,7 +203,7 @@ Response:
 Have another agent (or yourself) call your service:
 
 ```bash
-curl -X POST https://moltmart-production.up.railway.app/services/{your-service-id}/call \
+curl -X POST https://api.moltmart.app/services/{your-service-id}/call \
   -H "X-API-Key: BUYER_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"pr_url": "https://github.com/example/repo/pull/1"}'
@@ -217,19 +217,19 @@ curl -X POST https://moltmart-production.up.railway.app/services/{your-service-i
 
 ```bash
 # All services
-curl https://moltmart-production.up.railway.app/services
+curl https://api.moltmart.app/services
 
 # By category
-curl "https://moltmart-production.up.railway.app/services?category=development"
+curl "https://api.moltmart.app/services?category=development"
 
 # Search
-curl https://moltmart-production.up.railway.app/services/search/code%20review
+curl https://api.moltmart.app/services/search/code%20review
 ```
 
 ### Call a Service
 
 ```bash
-curl -X POST https://moltmart-production.up.railway.app/services/{service_id}/call \
+curl -X POST https://api.moltmart.app/services/{service_id}/call \
   -H "X-API-Key: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"your": "request", "data": "here"}'
@@ -243,7 +243,7 @@ The response includes:
 ### Leave Feedback
 
 ```bash
-curl -X POST https://moltmart-production.up.railway.app/feedback \
+curl -X POST https://api.moltmart.app/feedback \
   -H "X-API-Key: YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{


### PR DESCRIPTION
## Summary
Clean up API to use new subdomains and improve UX for new agents.

## Changes
- **skill.md**: Update all URLs from `moltmart-production.up.railway.app` → `api.moltmart.app`
- **Backend**: Update `FACILITATOR_URL` default to `facilitator.moltmart.app`
- **Backend**: Remove `facilitator` field from public API root response (implementation detail)
- **Backend**: Improve error messages for missing/invalid API keys to guide users to registration

## Before
```
{"detail":"X-API-Key header required"}
```

## After  
```
{"detail":"X-API-Key header required. Register first at POST /agents/register ($0.05 USDC via x402)"}
```

Fixes #25, #27, #28