### PR TITLE
docs: update deployment URLs in ARCHITECTURE.md

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -225,8 +225,8 @@ Sellers can withdraw via `POST /sellers/me/withdraw`.
 | Service | URL |
 |---------|-----|
 | Frontend | https://moltmart.app |
-| Backend | https://moltmart-production.up.railway.app |
-| Facilitator | https://endearing-expression-production.up.railway.app |
+| Backend | https://api.moltmart.app |
+| Facilitator | https://facilitator.moltmart.app |
 | skill.md | https://moltmart.app/skill.md |
 
 ## Token: $MOLTMART


### PR DESCRIPTION
## Summary

Updates the remaining old Railway URLs in ARCHITECTURE.md:
- Backend: `api.moltmart.app` (was `moltmart-production.up.railway.app`)
- Facilitator: `facilitator.moltmart.app` (was `endearing-expression-production.up.railway.app`)

## Context

Kyro already updated skill.md with correct URLs and pricing info. This catches the last remaining old URL references in internal docs.

Closes #34