### PR TITLE
fix: convert HexBytes to hex string before comparison

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -769,7 +769,8 @@ async def verify_onchain_challenge(wallet_address: str, tx_hash: str) -> tuple[b
             return False, f"Transaction target {tx['to']} doesn't match expected {expected_target}"
         
         # Verify calldata contains our nonce
-        tx_input = tx["input"].lower() if tx["input"] else "0x"
+        # Note: tx["input"] is HexBytes, need .hex() to convert to string
+        tx_input = tx["input"].hex().lower() if tx["input"] else "0x"
         if tx_input != expected_calldata.lower():
             return False, f"Transaction calldata doesn't match. Expected {expected_calldata}, got {tx_input}"
         


### PR DESCRIPTION
## Problem

On-chain verification always fails with `calldata doesn't match` even when the calldata is correct.

## Root Cause

`tx['input']` from web3.py is a `HexBytes` object, not a string. Calling `.lower()` on `HexBytes` doesn't convert it to a hex string—it returns the raw bytes.

**Before:**
```python
tx_input = tx['input'].lower()  # → b'cj\x17\xa3...' (bytes representation)
```

**After:**
```python
tx_input = tx['input'].hex().lower()  # → '0x636a17a3...' (hex string)
```

## Testing

I hit this while testing the custodial wallet registration flow with Bankr:
1. Got challenge: `0x636a17a3686382b116d59fd1ea3d1c66`
2. Sent tx with correct calldata: `0x48a7b836d0154b237e935978c6759de4e0397d57039734883cff8c7ce2d6b938`
3. Registration failed with: `Expected 0x636a17a3..., got b'cj\x17\xa3...'`

The bytes decode to the same value—just wrong type comparison.

## Fix

One-line change: add `.hex()` before `.lower()`