### PR TITLE
fix: use w3.to_hex() to include 0x prefix

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -769,8 +769,8 @@ async def verify_onchain_challenge(wallet_address: str, tx_hash: str) -> tuple[b
             return False, f"Transaction target {tx['to']} doesn't match expected {expected_target}"
         
         # Verify calldata contains our nonce
-        # Note: tx["input"] is HexBytes, need .hex() to convert to string
-        tx_input = tx["input"].hex().lower() if tx["input"] else "0x"
+        # Note: tx["input"] is HexBytes - use w3.to_hex() for proper conversion with 0x prefix
+        tx_input = w3.to_hex(tx["input"]).lower() if tx["input"] else "0x"
         if tx_input != expected_calldata.lower():
             return False, f"Transaction calldata doesn't match. Expected {expected_calldata}, got {tx_input}"
         


### PR DESCRIPTION
Follow-up to PR #41.

`.hex()` returns `922bfc21...` (no prefix)
`w3.to_hex()` returns `0x922bfc21...` (with prefix)

The expected calldata has `0x` prefix, so the comparison was still failing:
```
Expected 0xb06e7230c894eaf5cdc7df385c8dd0d8
Got      b06e7230c894eaf5cdc7df385c8dd0d8
```

One-line fix, verified against web3.py docs.