### PR TITLE
feat(frontend): Add testnet UI indicator and network-aware configuration

### DIFF
--- a/frontend/src/app/agents/[wallet]/page.tsx
+++ b/frontend/src/app/agents/[wallet]/page.tsx
@@ -6,8 +6,9 @@ import Link from "next/link";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { apiUrl } from "@/components/network-banner";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "https://api.moltmart.app";
+const API_URL = apiUrl;
 
 interface Agent {
   id: string;

--- a/frontend/src/app/agents/page.tsx
+++ b/frontend/src/app/agents/page.tsx
@@ -4,8 +4,9 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { apiUrl } from "@/components/network-banner";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "https://api.moltmart.app";
+const API_URL = apiUrl;
 
 interface Agent {
   id: string;

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { NetworkBanner } from "@/components/network-banner";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -40,6 +41,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <NetworkBanner />
         {children}
       </body>
     </html>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -12,8 +12,9 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { NetworkBadge, isTestnet, apiUrl, baseUrl } from "@/components/network-banner";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "https://api.moltmart.app";
+const API_URL = apiUrl;
 
 interface ERC8004Credentials {
   has_8004: boolean;
@@ -228,16 +229,17 @@ export default function Home() {
           <p className="mb-6 text-emerald-950 text-base md:text-lg">
             Paste this into your agent&apos;s context to start listing services
           </p>
-          <CopyCommand command="curl -s https://moltmart.app/skill.md" />
+          <CopyCommand command={`curl -s ${baseUrl}/skill.md`} />
         </div>
       </div>
 
       {/* Header */}
       <header className="border-b border-zinc-800/50 px-6 py-4 backdrop-blur-sm bg-black/50 sticky top-0 z-50">
         <div className="max-w-6xl mx-auto flex justify-between items-center">
-          <h1 className="text-2xl font-bold tracking-tight">
-            <span className="text-emerald-400">Molt</span>Mart 
-            <Badge variant="secondary" className="ml-2 text-xs">beta</Badge>
+          <h1 className="text-2xl font-bold tracking-tight flex items-center gap-2">
+            <span><span className="text-emerald-400">Molt</span>Mart</span>
+            <Badge variant="secondary" className="text-xs">beta</Badge>
+            <NetworkBadge />
           </h1>
           <nav className="flex gap-4 text-sm">
             <Button variant="ghost" asChild>
@@ -329,7 +331,7 @@ export default function Home() {
                   <div className="bg-black/50 rounded-xl p-6 border border-zinc-800 font-mono text-sm">
                     <div className="text-zinc-500 mb-2"># Mint your ERC-8004 identity</div>
                     <div className="text-emerald-400">curl -X POST \</div>
-                    <div className="text-zinc-300 pl-4">https://api.moltmart.app/identity/mint \</div>
+                    <div className="text-zinc-300 pl-4">{API_URL}/identity/mint \</div>
                     <div className="text-zinc-300 pl-4">-H &quot;Content-Type: application/json&quot; \</div>
                     <div className="text-zinc-300 pl-4">-d &apos;&#123;&quot;wallet_address&quot;: &quot;0x...&quot;&#125;&apos;</div>
                     <div className="text-zinc-500 mt-4"># Returns 402 → pay with x402 → get NFT</div>

--- a/frontend/src/components/network-banner.tsx
+++ b/frontend/src/components/network-banner.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "https://api.moltmart.app";
+
+// Detect testnet based on API URL
+const isTestnet = API_URL.includes("testnet") || API_URL.includes("localhost") || API_URL.includes("sepolia");
+
+// Base URL for frontend (skill.md, etc.)
+const baseUrl = isTestnet ? "https://testnet.moltmart.app" : "https://moltmart.app";
+
+export function NetworkBanner() {
+  if (!isTestnet) return null;
+
+  return (
+    <div className="bg-amber-500/90 text-black px-4 py-2 text-center text-sm font-medium sticky top-0 z-50">
+      <span className="inline-flex items-center gap-2">
+        <span className="animate-pulse">⚠️</span>
+        <span>
+          <strong>TESTNET MODE</strong> — Base Sepolia · Test USDC only · No real funds
+        </span>
+        <span className="animate-pulse">⚠️</span>
+      </span>
+    </div>
+  );
+}
+
+export function NetworkBadge() {
+  if (!isTestnet) {
+    return (
+      <span className="inline-flex items-center gap-1 text-xs bg-emerald-500/10 text-emerald-400 border border-emerald-500/30 px-2 py-0.5 rounded-full">
+        <span className="w-2 h-2 bg-emerald-400 rounded-full"></span>
+        Base Mainnet
+      </span>
+    );
+  }
+  
+  return (
+    <span className="inline-flex items-center gap-1 text-xs bg-amber-500/10 text-amber-400 border border-amber-500/30 px-2 py-0.5 rounded-full">
+      <span className="w-2 h-2 bg-amber-400 rounded-full animate-pulse"></span>
+      Base Sepolia (Testnet)
+    </span>
+  );
+}
+
+// Export for use in other components
+export { isTestnet, API_URL as apiUrl, baseUrl };


### PR DESCRIPTION
## Summary

Adds visual indicators and dynamic configuration for testnet deployment.

## Changes

- **New component:** `network-banner.tsx`
  - `NetworkBanner`: Amber warning banner at top when on testnet
  - `NetworkBadge`: Shows network status (Base Mainnet / Base Sepolia) in header
  - Centralized `apiUrl` and `baseUrl` exports
  - Auto-detects testnet based on `NEXT_PUBLIC_API_URL`

- **Updated pages:**
  - `layout.tsx`: Added NetworkBanner to body
  - `page.tsx`: Added NetworkBadge to header, dynamic example URLs
  - `agents/page.tsx`: Import apiUrl from network-banner
  - `agents/[wallet]/page.tsx`: Import apiUrl from network-banner

## How it works

When deployed to testnet.moltmart.app with:
```
NEXT_PUBLIC_API_URL=https://testnet-api.moltmart.app
```

The UI automatically:
- Shows amber **TESTNET MODE** banner at top of page
- Shows **Base Sepolia (Testnet)** badge in header
- Updates example URLs (skill.md, API endpoints) to testnet

## Screenshot (testnet mode)

The banner will look like:
```
⚠️ TESTNET MODE — Base Sepolia · Test USDC only · No real funds ⚠️
```

## No breaking changes

Default behavior unchanged when `NEXT_PUBLIC_API_URL` is not set or points to mainnet.

---
Relates to #62 (Testnet Deployment Plan)