### PR TITLE
fix: use build-time env var for skill.md

### DIFF
--- a/frontend/src/app/skill.md/route.ts
+++ b/frontend/src/app/skill.md/route.ts
@@ -1,20 +1,14 @@
-import { NextResponse, NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
 import fs from 'fs';
 import path from 'path';
 
-export const dynamic = 'force-dynamic';
+// This gets baked in at BUILD time - each Railway environment 
+// builds separately with its own env vars
+const API_URL = process.env.NEXT_PUBLIC_API_URL || '';
+const IS_TESTNET = API_URL.includes('testnet');
 
-export async function GET(request: NextRequest) {
-  // Check multiple headers - proxies may modify 'host'
-  const host = request.headers.get('host') || '';
-  const forwardedHost = request.headers.get('x-forwarded-host') || '';
-  const url = request.url || '';
-  
-  const isTestnet = host.includes('testnet') || 
-                    forwardedHost.includes('testnet') || 
-                    url.includes('testnet');
-  
-  const filename = isTestnet ? 'skill-testnet.md' : 'skill-production.md';
+export async function GET() {
+  const filename = IS_TESTNET ? 'skill-testnet.md' : 'skill-production.md';
   const filePath = path.join(process.cwd(), 'public', filename);
   const content = fs.readFileSync(filePath, 'utf-8');
   


### PR DESCRIPTION
Since each Railway environment builds separately with its own env vars, use the build-time value of NEXT_PUBLIC_API_URL to decide which file to serve.

This is simpler and more reliable than runtime header detection.