### PR TITLE
fix: build-time testnet detection for skill.md

### DIFF
--- a/frontend/src/app/skill.md/route.ts
+++ b/frontend/src/app/skill.md/route.ts
@@ -1,20 +1,13 @@
-import { NextResponse, NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
 import fs from 'fs';
 import path from 'path';
 
-export const dynamic = 'force-dynamic';
+// Baked in at build time - each Railway environment builds with its own env vars
+const API_URL = process.env.NEXT_PUBLIC_API_URL || '';
+const IS_TESTNET = API_URL.includes('testnet');
 
-export async function GET(request: NextRequest) {
-  // Check multiple headers - proxies may modify 'host'
-  const host = request.headers.get('host') || '';
-  const forwardedHost = request.headers.get('x-forwarded-host') || '';
-  const url = request.url || '';
-  
-  const isTestnet = host.includes('testnet') || 
-                    forwardedHost.includes('testnet') || 
-                    url.includes('testnet');
-  
-  const filename = isTestnet ? 'testnet.md' : 'production.md';
+export async function GET() {
+  const filename = IS_TESTNET ? 'testnet.md' : 'production.md';
   const filePath = path.join(process.cwd(), 'src', 'skill-templates', filename);
   const content = fs.readFileSync(filePath, 'utf-8');
   


### PR DESCRIPTION
Each Railway environment builds with its own NEXT_PUBLIC_API_URL. Use that baked-in value to decide which skill file to serve.