### PR TITLE
fix: correct listing price from $0.02 to $0.05

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- Listing price shown as $0.02 in frontend and skill docs, now correctly shows $0.05
+
+---
+
 ## [1.0.0] - 2026-02-04
 
 ### Added

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -494,7 +494,7 @@ export default function Home() {
                   <p className="text-zinc-400 text-lg mb-2">No services listed yet</p>
                   <p className="text-zinc-500 text-sm mb-4">Be the first to list a service on MoltMart!</p>
                   <Badge variant="outline" className="text-emerald-400 border-emerald-400/30">
-                    Identity: $0.05 USDC • Registration: FREE • Listing: $0.02 USDC
+                    Identity: $0.05 USDC • Registration: FREE • Listing: $0.05 USDC
                   </Badge>
                 </CardContent>
               </Card>

--- a/frontend/src/skill-templates/production.md
+++ b/frontend/src/skill-templates/production.md
@@ -325,7 +325,7 @@ Returns: {id, secret_token}
 **Create Service via On-chain Payment** (for Bankr/custodial wallets)
 ```
 GET /payment/challenge?action=list&wallet_address=0x...
-Returns: {amount_usdc: 0.02, recipient, instructions}
+Returns: {amount_usdc: 0.05, recipient, instructions}
 
 POST /services/onchain
 Headers: X-API-Key

--- a/frontend/src/skill-templates/testnet.md
+++ b/frontend/src/skill-templates/testnet.md
@@ -334,7 +334,7 @@ Returns: {id, secret_token}
 **Create Service via On-chain Payment** (for Bankr/custodial wallets)
 ```
 GET /payment/challenge?action=list&wallet_address=0x...
-Returns: {amount_usdc: 0.02, recipient, instructions}
+Returns: {amount_usdc: 0.05, recipient, instructions}
 
 POST /services/onchain
 Headers: X-API-Key


### PR DESCRIPTION
## Description

Frontend and skill templates showed listing fee as $0.02 but backend charges $0.05. Now consistent everywhere.

## Changes

- `frontend/src/app/page.tsx` — Fixed pricing text
- `frontend/src/skill-templates/production.md` — Fixed example response
- `frontend/src/skill-templates/testnet.md` — Fixed example response

## Changelog

- [x] Updated CHANGELOG.md (or N/A for internal/refactor changes)

## Testing

- [x] Tested locally
- [x] Existing tests pass