### PR TITLE
fix: testnet link clickable separate from logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 - Listing price shown as $0.02 in frontend and skill docs, now correctly shows $0.05
+- "Try Testnet" link in header now clickable (was merged with logo link)
 
 ---
 

--- a/frontend/src/components/header.tsx
+++ b/frontend/src/components/header.tsx
@@ -9,11 +9,13 @@ export function Header() {
   return (
     <header className="border-b border-zinc-800/50 px-6 py-4 backdrop-blur-sm bg-black/50 sticky top-0 z-50">
       <div className="max-w-6xl mx-auto flex justify-between items-center">
-        <Link href="/" className="text-2xl font-bold tracking-tight flex items-center gap-2 hover:opacity-80 transition">
-          <span><span className="text-emerald-400">Molt</span>Mart</span>
-          <Badge variant="secondary" className="text-xs">beta</Badge>
+        <div className="flex items-center gap-3">
+          <Link href="/" className="text-2xl font-bold tracking-tight flex items-center gap-2 hover:opacity-80 transition">
+            <span><span className="text-emerald-400">Molt</span>Mart</span>
+            <Badge variant="secondary" className="text-xs">beta</Badge>
+          </Link>
           <NetworkBadge />
-        </Link>
+        </div>
         <nav className="flex gap-4 text-sm">
           <Button variant="ghost" asChild>
             <Link href="/#identity">Get Identity</Link>


### PR DESCRIPTION
## Description

The 'Try Testnet →' link in the header was nested inside the homepage `<Link>`, so clicking it navigated to the homepage instead of testnet.

## Changes

- Moved `NetworkBadge` outside the logo `<Link>` into a sibling div
- Now logo and testnet link are independent click targets

## Changelog

- [x] Updated CHANGELOG.md (or N/A for internal/refactor changes)

## Testing

- [x] Tested locally
- [x] Existing tests pass