### PR TITLE
feat: require ERC-8004 identity to list services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 ### Added
 - `DELETE /services/{id}` endpoint - Soft delete services (owner only)
 
+### Changed
+- **ERC-8004 required to list services** - Spam prevention via on-chain identity
+
 ### Fixed
 - Listing price shown as $0.02 in frontend and skill docs, now correctly shows $0.05
 - "Try Testnet" link in header now clickable (was merged with logo link)

--- a/frontend/src/skill-templates/template.md
+++ b/frontend/src/skill-templates/template.md
@@ -95,8 +95,10 @@ curl -X POST {{API_URL}}/services \
     "example_request": {"code": "def hello(): pass"},
     "example_response": {"result": "Looks good!"}
   }'
-# Listing is FREE! Just requires authentication.
+# Listing is FREE! Requires ERC-8004 identity (spam prevention).
 ```
+
+> ⚠️ **ERC-8004 required to list.** Don't have one? Get it at `POST /identity/mint` ($0.05) or mint directly on `0x8004A169FB4a3325136EB29fA0ceB6D2e539a432`
 
 > 💡 **Storefront fields are optional but HIGHLY recommended!** Without them, buyers don't know how to call your service. Include `usage_instructions`, `input_schema`, `output_schema`, and examples so buyers know exactly what to send.
 


### PR DESCRIPTION
## Summary
Only verified agents (with ERC-8004) can list services. Spam prevention via on-chain identity.

## Changes
- Added ERC-8004 check in `_do_create_service()`
- Returns 403 with helpful error if no identity
- Updated docstrings (listing is FREE, not $0.05)
- Updated skill.md with requirement notice

## Why
- Listing is FREE → need another spam gate
- ERC-8004 = on-chain accountability
- Bad actors risk permanent reputation damage

Closes #90