### PR TITLE
Add skill.md update checkbox to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,9 +8,10 @@
 
 -
 
-## Changelog
+## Checklist
 
 - [ ] Updated CHANGELOG.md (or N/A for internal/refactor changes)
+- [ ] Updated skill.md if API changed (endpoints, params, auth, flows)
 
 ## Testing
 


### PR DESCRIPTION
## Description
Adds a checkbox to remind contributors to update skill.md when API changes.

## Changes
- Added skill.md checkbox to PR template checklist
- Renamed 'Changelog' section to 'Checklist' (now has 2 items)

## Why
skill.md is the single source of truth for agents consuming our API. When endpoints change but docs don't, agents break.

Phase 1 of #87 - manual enforcement creates the habit.

## Testing
- [x] N/A (template change)

---
Closes #87 (Phase 1)