### PR TITLE
Add API key recovery endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 - `DELETE /services/{id}` endpoint - Soft delete services (owner only)
+- `POST /agents/recover-key` endpoint - Recover API key if lost (same challenge as registration)
 
 ### Changed
 - **ERC-8004 required to list services** - Spam prevention via on-chain identity

--- a/backend/database.py
+++ b/backend/database.py
@@ -391,6 +391,20 @@ async def delete_agent_by_wallet(wallet: str) -> bool:
         return False
 
 
+async def update_agent_api_key(wallet: str, new_api_key: str) -> bool:
+    """Update an agent's API key (for key recovery)."""
+    async with get_session() as session:
+        result = await session.execute(
+            select(AgentDB).where(AgentDB.wallet_address == wallet.lower())
+        )
+        agent = result.scalar_one_or_none()
+        if agent:
+            agent.api_key = new_api_key
+            await session.commit()
+            return True
+        return False
+
+
 # ============ SERVICE OPERATIONS ============
 
 

--- a/frontend/src/skill-templates/template.md
+++ b/frontend/src/skill-templates/template.md
@@ -311,6 +311,15 @@ Note: Provide erc8004_id if you already have an ERC-8004 identity (we verify own
 If not provided, we'll check if you have one via balanceOf.
 ```
 
+**Recover API Key** (lost your key?)
+```
+POST /agents/recover-key
+Body: {wallet_address, signature}  # or tx_hash for on-chain verification
+Returns: {success, api_key, message}
+
+Use the same challenge from GET /agents/challenge. Old key is invalidated.
+```
+
 ### Services
 
 **List Services**


### PR DESCRIPTION
## Description
Adds `POST /agents/recover-key` endpoint for agents who lost their API key.

## Problem
If an agent loses their API key, they're locked out forever. The wallet is registered so they can't re-register, and there's no way to get a new key.

## Solution
New endpoint that:
1. Verifies wallet ownership (same challenge as registration)
2. Generates new API key
3. Invalidates old key

## Changes
- `database.py`: Added `update_agent_api_key()` function
- `main.py`: Added `POST /agents/recover-key` endpoint
- `skill-templates/template.md`: Documented new endpoint
- `CHANGELOG.md`: Added to Unreleased

## Checklist
- [x] Updated CHANGELOG.md
- [x] Updated skill.md

## Testing
- [x] Syntax check passes
- [ ] Integration test after deploy (will test with my own wallet)

---
Real bug that blocked me earlier today - needed this to test production flow.