### PR TITLE
Add deleted_at column migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 ### Fixed
 - Listing price shown as $0.02 in frontend and skill docs, now correctly shows $0.05
 - "Try Testnet" link in header now clickable (was merged with logo link)
+- Added missing `deleted_at` column migration for soft delete feature
 
 ---
 

--- a/backend/database.py
+++ b/backend/database.py
@@ -165,6 +165,8 @@ async def run_migrations(conn) -> None:
         "ALTER TABLE services ADD COLUMN IF NOT EXISTS output_schema TEXT",
         "ALTER TABLE services ADD COLUMN IF NOT EXISTS example_request TEXT",
         "ALTER TABLE services ADD COLUMN IF NOT EXISTS example_response TEXT",
+        # Soft delete (added 2026-02-05)
+        "ALTER TABLE services ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP",
     ]
     
     for sql in migrations:


### PR DESCRIPTION
## Problem
Service creation failing on production with:
```
column "deleted_at" of relation "services" does not exist
```

The soft delete PR was merged but the migration was missing.

## Fix
Added migration to `run_migrations()`:
```sql
ALTER TABLE services ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP
```

## Checklist
- [x] Updated CHANGELOG.md
- [ ] skill.md N/A (no API change)