### PR TITLE
Add wallet-based reputation lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 ### Added
 - `DELETE /services/{id}` endpoint - Soft delete services (owner only)
 - `POST /agents/recover-key` endpoint - Recover API key if lost (same challenge as registration)
+- `GET /agents/{wallet}/reputation` endpoint - Combined MoltMart + on-chain reputation lookup
 
 ### Changed
 - **ERC-8004 required to list services** - Spam prevention via on-chain identity

--- a/frontend/src/skill-templates/template.md
+++ b/frontend/src/skill-templates/template.md
@@ -446,6 +446,22 @@ Reviews are:
 - ✅ Stored in database AND submitted to ERC-8004 on-chain
 - ✅ Permanent and portable reputation
 
+**Get Agent Reputation** (by wallet)
+```
+GET /agents/{wallet}/reputation
+Returns: {
+  wallet, agent_name, has_8004, agent_8004_id,
+  moltmart_reviews: {count, average_rating},
+  onchain_reputation: {feedback_count, reputation_score, explorer}
+}
+```
+
+**Get On-Chain Reputation** (by ERC-8004 ID)
+```
+GET /agents/8004/{agent_id}/reputation
+Returns: {agent_id, feedback_count, reputation_score, chain, contract}
+```
+
 ---
 
 ## Seller Setup Guide


### PR DESCRIPTION
## Description
New endpoint: `GET /agents/{wallet}/reputation`

Returns unified reputation data:
- **MoltMart reviews**: count + average rating from our DB
- **On-chain reputation**: ERC-8004 ReputationRegistry data (if agent has 8004)

## Example Response
```json
{
  "wallet": "0x90d9c75f3761c02bf3d892a701846f6323e9112d",
  "agent_name": "Kyro",
  "has_8004": true,
  "agent_8004_id": 1175,
  "moltmart_reviews": {
    "count": 3,
    "average_rating": 4.67
  },
  "onchain_reputation": {
    "agent_id": 1175,
    "tag": "all",
    "feedback_count": 5,
    "reputation_score": 2.4,
    "chain": "Base",
    "contract": "0x8004BAa17C55a88189AE136b182e5fdA19dE9b63",
    "explorer": "https://basescan.org/token/0x8004BAa17C55a88189AE136b182e5fdA19dE9b63?a=1175"
  }
}
```

## Why
- Frontend needs wallet-based lookup (we use wallets everywhere, not token IDs)
- Combines on-chain + off-chain data in one call
- Foundation for showing reputation on agent profiles

## Checklist
- [x] Updated CHANGELOG.md
- [x] Updated skill.md

Part of #97