### PR TITLE
Fix get_reputation to call getClients first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 - Listing price shown as $0.02 in frontend and skill docs, now correctly shows $0.05
 - "Try Testnet" link in header now clickable (was merged with logo link)
 - Added missing `deleted_at` column migration for soft delete feature
+- Fixed `get_reputation()` - must call `getClients()` first before `getSummary()`
 
 ---
 

--- a/backend/erc8004.py
+++ b/backend/erc8004.py
@@ -329,10 +329,22 @@ def get_reputation(agent_id: int, tag: str = "") -> dict:
         return {"error": "Reputation registry not configured"}
 
     try:
+        # First get the list of clients who have given feedback
+        clients = reputation_registry.functions.getClients(agent_id).call()
+        
+        # If no clients, agent has no feedback yet
+        if not clients:
+            return {
+                "agent_id": agent_id,
+                "feedback_count": 0,
+                "reputation_score": 0,
+                "decimals": 0,
+            }
+        
         # getSummary(agentId, clientAddresses[], tag1, tag2)
         count, value, decimals = reputation_registry.functions.getSummary(
             agent_id,
-            [],  # all clients
+            clients,  # pass the actual client list
             tag,  # tag1 filter
             "",  # tag2 filter
         ).call()


### PR DESCRIPTION
## Problem
`get_reputation()` was passing empty `[]` for clientAddresses, causing:
```
execution reverted: clientAddresses required
```

## Fix
1. Call `getClients(agentId)` first to get list of addresses who gave feedback
2. Pass that list to `getSummary()`
3. Return 0 feedback count if no clients yet (new agents)

## Testing
Syntax checked locally. Will verify on production after merge.

## Checklist
- [x] Updated CHANGELOG.md
- [ ] skill.md N/A (internal fix)