### PR TITLE
fix: add missing endpoint_url migration (CRITICAL)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 - **ERC-8004 required to list services** - Spam prevention via on-chain identity
 
 ### Fixed
+- **CRITICAL: endpoint_url not persisted** - Column was in model but never migrated to database. All services had null endpoints. (#104)
 - Listing price shown as $0.02 in frontend and skill docs, now correctly shows $0.05
 - "Try Testnet" link in header now clickable (was merged with logo link)
 - Added missing `deleted_at` column migration for soft delete feature

--- a/backend/database.py
+++ b/backend/database.py
@@ -159,6 +159,8 @@ async def run_migrations(conn) -> None:
         return  # SQLite auto-handles this via create_all
     
     migrations = [
+        # CRITICAL: endpoint_url was in model but never migrated (fixed 2026-02-05)
+        "ALTER TABLE services ADD COLUMN IF NOT EXISTS endpoint_url VARCHAR",
         # Service storefront fields (added 2026-02-04)
         "ALTER TABLE services ADD COLUMN IF NOT EXISTS usage_instructions TEXT",
         "ALTER TABLE services ADD COLUMN IF NOT EXISTS input_schema TEXT",


### PR DESCRIPTION
## Problem

The `endpoint_url` column was defined in the `ServiceDB` model but **never added to the migrations list**. This caused:

- All services to have `endpoint_url = null` in the database
- Service creation appeared to work (returned the URL in response) but didn't persist
- **Core marketplace functionality broken** - can't route requests to sellers

## Root Cause

The `endpoint_url` column was in the model since the beginning, but the `run_migrations()` function only adds columns that were added *after* initial deployment. Since `endpoint_url` was in the original model but the database was created before it existed in production, the column was never created.

## Fix

Added migration:
```sql
ALTER TABLE services ADD COLUMN IF NOT EXISTS endpoint_url VARCHAR
```

## Impact

After merge + deploy:
1. Database will have the column
2. New services will persist endpoint_url correctly
3. **Existing services need to be updated** - their endpoint_url values were lost

## Testing

- [ ] Deploy to testnet first
- [ ] Verify column exists: `SELECT endpoint_url FROM services LIMIT 1`
- [ ] Create new service, verify endpoint_url persists
- [ ] Update existing service, verify endpoint_url persists

Fixes #104

cc @kali-claw - thanks for catching this!